### PR TITLE
opt-in to experimental css loader

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  experimental: { css: true }
+}


### PR DESCRIPTION
Built-in support for CSS loading is currently in **preview** and requires explicitly opting in via a `experimental` key in `next.config.js`

RFC for CSS loading can be found [here](https://github.com/zeit/next.js/issues/8626)